### PR TITLE
Add dropdown page routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,12 +19,14 @@ import Footer from './components/Footer';
 import Contact from './pages/Contact';
 import About from './pages/About';
 import BlogPage from './pages/Blog';
-import ConsultingServices from './pages/ConsultingServices';
+import Consulting from './pages/Consulting';
+import EnterpriseContentManagement from './pages/EnterpriseContentManagement';
 import ISO27001 from './pages/ISO27001';
 import LeanSixSigma from './pages/LeanSixSigma';
 import ISO9001 from './pages/ISO9001';
 import IMS from './pages/IMS';
 import AS9100 from './pages/AS9100';
+import TrainingHome from './pages/Training';
 import TrainingCMMI from './pages/TrainingCMMI';
 import TrainingISO from './pages/TrainingISO';
 import TrainingLeanSixSigma from './pages/TrainingLeanSixSigma';
@@ -45,17 +47,19 @@ const App = () => {
   if (path.startsWith('/contact')) return <Contact />;
   if (path.startsWith('/about-us')) return <About />;
   if (path.startsWith('/blog')) return <BlogPage />;
-  if (path.startsWith('/consulting-services')) return <ConsultingServices />;
-  if (path.startsWith('/iso-27001')) return <ISO27001 />;
-  if (path.startsWith('/lean-six-sigma')) return <LeanSixSigma />;
-  if (path.startsWith('/iso-9001')) return <ISO9001 />;
-  if (path.startsWith('/ims')) return <IMS />;
-  if (path.startsWith('/as-9100')) return <AS9100 />;
-  if (path.startsWith('/training/cmmi')) return <TrainingCMMI />;
-  if (path.startsWith('/training/iso')) return <TrainingISO />;
+  if (path === '/consulting-services' || path === '/consulting-services/') return <Consulting />;
+  if (path.startsWith('/consulting-services/enterprise-content-management')) return <EnterpriseContentManagement />;
+  if (path.startsWith('/consulting-services/information-security-management-systems') || path.startsWith('/iso-27001')) return <ISO27001 />;
+  if (path.startsWith('/consulting-services/lean-six-sigma') || path.startsWith('/lean-six-sigma')) return <LeanSixSigma />;
+  if (path.startsWith('/consulting-services/quality-management-iso-9000-family') || path.startsWith('/iso-9001')) return <ISO9001 />;
+  if (path.startsWith('/consulting-services/integrated-management-system') || path.startsWith('/ims')) return <IMS />;
+  if (path.startsWith('/aerospace-quality-mgmt-systems-as-9100') || path.startsWith('/as-9100')) return <AS9100 />;
+  if (path === '/training' || path === '/training/') return <TrainingHome />;
+  if (path.startsWith('/training/cmmi-models') || path.startsWith('/training/cmmi')) return <TrainingCMMI />;
+  if (path.startsWith('/training/iso-standards') || path.startsWith('/training/iso')) return <TrainingISO />;
   if (path.startsWith('/training/lean-six-sigma')) return <TrainingLeanSixSigma />;
-  if (path.startsWith('/training/ims')) return <TrainingIMS />;
-  if (path.startsWith('/training/evm')) return <TrainingEVM />;
+  if (path.startsWith('/training/integrated-management-system') || path.startsWith('/training/ims')) return <TrainingIMS />;
+  if (path.startsWith('/training/earned-value-management-evm') || path.startsWith('/training/evm')) return <TrainingEVM />;
 
   return (
     <div className="min-h-screen">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -23,26 +23,26 @@ const Header = () => {
               
               {/* Consulting Dropdown */}
               <div className="relative group">
-                <button className="text-gray-600 hover:text-blue-900 focus:outline-none">Consulting</button>
+                <a href="/consulting-services/" className="text-gray-600 hover:text-blue-900 focus:outline-none">Consulting</a>
                 <div className="absolute left-0 mt-2 w-72 bg-white border rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-50">
-                  <a href="/consulting-services/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Enterprise Content Management</a>
-                  <a href="/iso-27001/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Information Security Management (ISO 27001)</a>
-                  <a href="/lean-six-sigma/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Lean Six Sigma</a>
-                  <a href="/iso-9001/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Quality Management System (ISO 9001)</a>
-                  <a href="/ims/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Integrated Management System (ISO 27001, 9001, 20000)</a>
-                  <a href="/as-9100/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Aerospace Quality Management Systems (AS 9100)</a>
+                  <a href="/consulting-services/enterprise-content-management" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Enterprise Content Management</a>
+                  <a href="/consulting-services/information-security-management-systems" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Information Security Management (ISO 27001)</a>
+                  <a href="/consulting-services/lean-six-sigma" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Lean Six Sigma</a>
+                  <a href="/consulting-services/quality-management-iso-9000-family" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Quality Management System (ISO 9001)</a>
+                  <a href="/consulting-services/integrated-management-system" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Integrated Management System (ISO 27001, 9001, 20000)</a>
+                  <a href="/aerospace-quality-mgmt-systems-as-9100" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Aerospace Quality Management Systems (AS 9100)</a>
                 </div>
               </div>
               
               {/* Training Dropdown */}
               <div className="relative group">
-                <button className="text-gray-600 hover:text-blue-900 focus:outline-none">Training</button>
+                <a href="/training/" className="text-gray-600 hover:text-blue-900 focus:outline-none">Training</a>
                 <div className="absolute left-0 mt-2 w-64 bg-white border rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-50">
-                  <a href="/training/cmmi/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">CMMI Models</a>
-                  <a href="/training/iso/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">ISO Standards</a>
-                  <a href="/training/lean-six-sigma/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Lean Six Sigma</a>
-                  <a href="/training/ims/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Integrated Management System</a>
-                  <a href="/training/evm/" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Earned Value Management (EVM)</a>
+                  <a href="/training/cmmi-models" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">CMMI Models</a>
+                  <a href="/training/iso-standards" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">ISO Standards</a>
+                  <a href="/training/lean-six-sigma" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Lean Six Sigma</a>
+                  <a href="/training/integrated-management-system" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Integrated Management System</a>
+                  <a href="/training/earned-value-management-evm" className="block px-4 py-2 hover:bg-gray-100 text-gray-700">Earned Value Management (EVM)</a>
                 </div>
               </div>
               
@@ -69,19 +69,21 @@ const Header = () => {
                   <a href="/" className="block text-gray-700 hover:bg-gray-100 px-2 py-1">Home</a>
                   
                   <p className="font-semibold text-gray-800 mt-2">Consulting</p>
-                  <a href="/consulting-services/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Enterprise Content Management</a>
-                  <a href="/iso-27001/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Information Security (ISO 27001)</a>
-                  <a href="/lean-six-sigma/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Lean Six Sigma</a>
-                  <a href="/iso-9001/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">ISO 9001</a>
-                  <a href="/ims/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Integrated Mgmt System</a>
-                  <a href="/as-9100/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">AS 9100</a>
+                  <a href="/consulting-services/" className="block text-gray-700 hover:bg-gray-100 px-2 py-1">Overview</a>
+                  <a href="/consulting-services/enterprise-content-management" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Enterprise Content Management</a>
+                  <a href="/consulting-services/information-security-management-systems" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Information Security (ISO 27001)</a>
+                  <a href="/consulting-services/lean-six-sigma" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Lean Six Sigma</a>
+                  <a href="/consulting-services/quality-management-iso-9000-family" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">ISO 9001</a>
+                  <a href="/consulting-services/integrated-management-system" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Integrated Mgmt System</a>
+                  <a href="/aerospace-quality-mgmt-systems-as-9100" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">AS 9100</a>
                   
                   <p className="font-semibold text-gray-800 mt-2">Training</p>
-                  <a href="/training/cmmi/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">CMMI Models</a>
-                  <a href="/training/iso/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">ISO Standards</a>
-                  <a href="/training/lean-six-sigma/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Lean Six Sigma</a>
-                  <a href="/training/ims/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Integrated Mgmt System</a>
-                  <a href="/training/evm/" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">EVM</a>
+                  <a href="/training/" className="block text-gray-700 hover:bg-gray-100 px-2 py-1">Overview</a>
+                  <a href="/training/cmmi-models" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">CMMI Models</a>
+                  <a href="/training/iso-standards" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">ISO Standards</a>
+                  <a href="/training/lean-six-sigma" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Lean Six Sigma</a>
+                  <a href="/training/integrated-management-system" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">Integrated Mgmt System</a>
+                  <a href="/training/earned-value-management-evm" className="block text-gray-600 hover:bg-gray-100 px-4 py-1">EVM</a>
                   
                   <a href="/blog/" className="block text-gray-700 hover:bg-gray-100 px-2 py-1">Blog</a>
                   <a href="/about-us/" className="block text-gray-700 hover:bg-gray-100 px-2 py-1">About</a>

--- a/src/pages/Consulting.jsx
+++ b/src/pages/Consulting.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import GenericPage from './GenericPage'
+
+const Consulting = () => (
+  <GenericPage title="Consulting Services" />
+)
+
+export default Consulting

--- a/src/pages/EnterpriseContentManagement.jsx
+++ b/src/pages/EnterpriseContentManagement.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import GenericPage from './GenericPage'
 
-const ConsultingServices = () => (
+const EnterpriseContentManagement = () => (
   <GenericPage title="Enterprise Content Management" />
 )
 
-export default ConsultingServices
+export default EnterpriseContentManagement

--- a/src/pages/Training.jsx
+++ b/src/pages/Training.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import GenericPage from './GenericPage'
+
+const TrainingHome = () => (
+  <GenericPage title="Training" />
+)
+
+export default TrainingHome


### PR DESCRIPTION
## Summary
- add Consulting and Training root pages
- rename EnterpriseContentManagement page
- update App route table for new nested paths
- adjust header dropdown links for new routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6853915345b48322a90a41e41f5fb80a